### PR TITLE
Docker in Ansible

### DIFF
--- a/ansible/image_chroot.yml
+++ b/ansible/image_chroot.yml
@@ -7,6 +7,7 @@
   roles:
     - common
     - devel
+    - docker
     - node6
     - python3
     - liquid-core

--- a/ansible/image_chroot.yml
+++ b/ansible/image_chroot.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install the board version of the liquid toolkit in chroot
   hosts: image
+  vars:
+    build_docker_images: false
   vars_files:
     - vars/defaults.yml
     - vars/config.yml
@@ -14,3 +16,4 @@
     - hotspot
     - hoover
     - hypothesis
+    - dokuwiki

--- a/ansible/image_host_docker.yml
+++ b/ansible/image_host_docker.yml
@@ -1,0 +1,12 @@
+---
+- name: Build docker containers in the temporary buildbot vm
+  hosts: local
+  vars:
+    build_docker_images: true
+  vars_files:
+    - vars/defaults.yml
+    - vars/config.yml
+  roles:
+    - docker
+  tasks:
+    - include: roles/dokuwiki/tasks/docker.yml

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,17 +1,6 @@
 ---
-- name: Import Docker GPG key
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-    state: present
-
-- name: Set up Docker repository
-  apt_repository:
-    repo: 'deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable'
-    filename: docker
-
 - name: Install docker
   apt: name={{ item }} state=latest
   with_items:
-    - docker-ce
+    - docker.io
     - docker-compose

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Import Docker GPG key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+    state: present
+
+- name: Set up Docker repository
+  apt_repository:
+    repo: 'deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable'
+    filename: docker
+
+- name: Install docker
+  apt: name={{ item }} state=latest
+  with_items:
+    - docker-ce
+    - docker-compose

--- a/ansible/roles/dokuwiki/tasks/docker.yml
+++ b/ansible/roles/dokuwiki/tasks/docker.yml
@@ -1,0 +1,21 @@
+---
+- name: Create folder
+  file:
+    path: /opt/dokuwiki
+    state: directory
+    mode: 0755
+
+- name: Write compose file
+  template:
+    # `src` is a relative path because this file is included
+    # directly from `image_host_docker.yml`, not as a role.
+    src: ../templates/docker-compose.yml
+    dest: /opt/dokuwiki/docker-compose.yml
+    mode: 644
+
+- name: Build docker image
+  when: build_docker_images
+  docker_service:
+    project_src: /opt/dokuwiki
+    build: true
+    stopped: true

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -17,6 +17,10 @@
     build: true
     stopped: true
 
+- name: Create supervisor config
+  template: src=supervisor/dokuwiki.conf
+            dest=/etc/supervisor/conf.d/dokuwiki.conf
+
 - name: Create nginx config
   template:
     src: nginx/dokuwiki.conf

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -1,21 +1,5 @@
 ---
-- name: Create folder
-  file:
-    path: /opt/dokuwiki
-    state: directory
-    mode: 0755
-
-- name: Write compose file
-  template:
-    src: docker-compose.yml
-    dest: /opt/dokuwiki/docker-compose.yml
-    mode: 644
-
-- name: Build docker image
-  docker_service:
-    project_src: /opt/dokuwiki
-    build: true
-    stopped: true
+- include: tasks/docker.yml
 
 - name: Create supervisor config
   template: src=supervisor/dokuwiki.conf

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Create folder
+  file:
+    path: /opt/dokuwiki
+    state: directory
+    mode: 0755
+
+- name: Write compose file
+  template:
+    src: docker-compose.yml
+    dest: /opt/dokuwiki/docker-compose.yml
+    mode: 644
+
+- name: Build docker image
+  docker_service:
+    project_src: /opt/dokuwiki
+    build: true
+    stopped: true

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -16,3 +16,8 @@
     project_src: /opt/dokuwiki
     build: true
     stopped: true
+
+- name: Create nginx config
+  template:
+    src: nginx/dokuwiki.conf
+    dest: /etc/nginx/sites-enabled/dokuwiki.conf

--- a/ansible/roles/dokuwiki/templates/docker-compose.yml
+++ b/ansible/roles/dokuwiki/templates/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+services:
+
+  dokuwiki:
+    image: istepanov/dokuwiki:2.0
+    volumes:
+      - dokuwiki:/var/dokuwiki-storage
+    ports:
+      - 61906:80
+
+volumes:
+  dokuwiki: {}

--- a/ansible/roles/dokuwiki/templates/nginx/dokuwiki.conf
+++ b/ansible/roles/dokuwiki/templates/nginx/dokuwiki.conf
@@ -1,0 +1,8 @@
+server {
+  listen 80;
+  server_name dokuwiki.{{ liquid_domain }};
+  location / {
+    proxy_pass http://localhost:61906;
+    proxy_set_header Host $host;
+  }
+}

--- a/ansible/roles/dokuwiki/templates/supervisor/dokuwiki.conf
+++ b/ansible/roles/dokuwiki/templates/supervisor/dokuwiki.conf
@@ -1,0 +1,4 @@
+[program:dokuwiki]
+directory = /opt/dokuwiki
+command = docker-compose up
+redirect_stderr = true

--- a/ansible/roles/liquid-core/templates/local.py
+++ b/ansible/roles/liquid-core/templates/local.py
@@ -19,3 +19,4 @@ HYPOTHESIS_USER_SCRIPTS = {
 
 HOOVER_APP_URL = 'http://hoover.{{ liquid_domain }}'
 HYPOTHESIS_APP_URL = 'http://hypothesis.{{ liquid_domain }}'
+DOKUWIKI_APP_URL = 'http://dokuwiki.{{ liquid_domain }}'

--- a/ansible/server.yml
+++ b/ansible/server.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install the server version of the Liquid Investigations toolkit
   hosts: local
+  vars:
+    build_docker_images: true
   vars_files:
     - vars/defaults.yml
     - vars/config.yml
@@ -13,3 +15,4 @@
     - liquid-core
     - hoover
     - hypothesis
+    - dokuwiki

--- a/ansible/server.yml
+++ b/ansible/server.yml
@@ -7,6 +7,7 @@
   roles:
     - common
     - devel
+    - docker
     - node6
     - python3
     - liquid-core

--- a/bin/build-x86_64-image.sh
+++ b/bin/build-x86_64-image.sh
@@ -18,6 +18,10 @@ apt-add-repository -y ppa:ansible/ansible
 apt-get update
 apt-get install -y ansible git qemu-utils
 
+cd $SETUPDIR/ansible
+touch vars/config.yml
+ansible-playbook image_host_docker.yml
+
 curl https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img > /mnt/shared/ubuntu-x86_64-cow2.img
 qemu-img convert -f qcow2 -O raw /mnt/shared/ubuntu-x86_64-cow2.img $IMAGE
 
@@ -40,8 +44,9 @@ chroot $TARGET apt-get update
 chroot $TARGET apt-get install -y python
 chroot $TARGET apt-get clean
 
-cd $SETUPDIR/ansible
-touch vars/config.yml
+service docker stop
+cp -a /var/lib/docker $TARGET/var/lib/docker
+
 ansible-playbook image_chroot.yml
 
 # console= setting referencing non-existant port can cause hangs during boot:

--- a/bin/build-x86_64-image.sh
+++ b/bin/build-x86_64-image.sh
@@ -60,3 +60,5 @@ umount $TARGET/proc
 umount $TARGET/dev
 umount $TARGET
 losetup -d /dev/loop0
+
+echo "done; image saved in $IMAGE"


### PR DESCRIPTION
This patch sets up docker using ansible and pulls in [this dokuwiki image](https://hub.docker.com/r/istepanov/dokuwiki/). For image building, since docker doesn't like chroot, the build script also installs docker in the kitchen bulidbot VM. Currently hardcoded for x86_64. Fixes liquidinvestigations/liquidinvestigations#36 liquidinvestigations/liquidinvestigations#24.

Remaining work:
* Integrate dokuwiki authentication with `liquid-core` (liquidinvestigations/liquidinvestigations#38)
* Port the dokuwiki image to `arm64` (liquidinvestigations/liquidinvestigations#41)