### PR TITLE
run dockerized matrix.org

### DIFF
--- a/ansible/image_chroot.yml
+++ b/ansible/image_chroot.yml
@@ -18,3 +18,4 @@
     - discover
     - hypothesis
     - dokuwiki
+    - matrix

--- a/ansible/roles/matrix/files/initialize.d/matrix
+++ b/ansible/roles/matrix/files/initialize.d/matrix
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cd /opt/matrix
+source libexec/setenv.sh
+set -x
+exec docker-compose run --rm \
+  -e SERVER_NAME="matrix.$LIQUID_DOMAIN" \
+  -e REPORT_STATS=no \
+  matrix generate

--- a/ansible/roles/matrix/files/supervisor/matrix.conf
+++ b/ansible/roles/matrix/files/supervisor/matrix.conf
@@ -1,0 +1,4 @@
+[program:dokuwiki]
+directory = /opt/dokuwiki
+command = docker-compose up --no-color
+redirect_stderr = true

--- a/ansible/roles/matrix/tasks/docker.yml
+++ b/ansible/roles/matrix/tasks/docker.yml
@@ -1,0 +1,21 @@
+---
+- name: Create folder
+  file:
+    path: /opt/matrix
+    state: directory
+    mode: 0755
+
+- name: Write compose file
+  template:
+    # `src` is a relative path because this file is included
+    # directly from `image_host_docker.yml`, not as a role.
+    src: ../templates/docker-compose.yml
+    dest: /opt/matrix/docker-compose.yml
+    mode: 644
+
+- name: Build docker image
+  when: build_docker_images
+  docker_service:
+    project_src: /opt/matrix
+    build: true
+    stopped: true

--- a/ansible/roles/matrix/tasks/main.yml
+++ b/ansible/roles/matrix/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- include: tasks/docker.yml
+
+- name: Create supervisor config
+  copy:
+    src: supervisor/matrix.conf
+    dest: /etc/supervisor/conf.d/matrix.conf
+
+- name: Create nginx config
+  template:
+    src: nginx/matrix.conf
+    dest: /etc/nginx/sites-enabled/matrix.conf
+
+- name: Create the libexec folder
+  file:
+    path: /opt/matrix/libexec
+    state: directory
+    mode: 0755
+
+- name: Create shell configuration file
+  template:
+    src: libexec/setenv.sh
+    dest: /opt/matrix/libexec/setenv.sh
+
+- name: Create the initialization script
+  copy:
+    src: initialize.d/matrix
+    dest: /opt/common/initialize.d/matrix
+    mode: 0755

--- a/ansible/roles/matrix/templates/docker-compose.yml
+++ b/ansible/roles/matrix/templates/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+services:
+
+  matrix:
+    image: silviof/docker-matrix
+    volumes:
+      - data:/data
+    ports:
+      - 55156:8008
+
+volumes:
+  data: {}

--- a/ansible/roles/matrix/templates/libexec/setenv.sh
+++ b/ansible/roles/matrix/templates/libexec/setenv.sh
@@ -1,0 +1,1 @@
+export LIQUID_DOMAIN="{{ liquid_domain }}"

--- a/ansible/roles/matrix/templates/nginx/matrix.conf
+++ b/ansible/roles/matrix/templates/nginx/matrix.conf
@@ -1,0 +1,9 @@
+server {
+  listen 80;
+  server_name matrix.{{ liquid_domain }};
+  location / {
+    proxy_pass http://localhost:55156;
+    proxy_ssl_verify off;
+    proxy_set_header Host $host;
+  }
+}

--- a/ansible/server.yml
+++ b/ansible/server.yml
@@ -17,3 +17,4 @@
     - discover
     - hypothesis
     - dokuwiki
+    - matrix


### PR DESCRIPTION
This patch adds the matrix docker container from https://hub.docker.com/r/silviof/docker-matrix/. It only runs on x86_64, and there's some weird database errors, but it technically runs, and takes you to the login screen. There are no users in its database though, so it's not really usable.
