### PR TITLE
Install dockerized davros

### DIFF
--- a/ansible/image_chroot.yml
+++ b/ansible/image_chroot.yml
@@ -19,3 +19,4 @@
     - hypothesis
     - dokuwiki
     - matrix
+    - davros

--- a/ansible/image_host_docker.yml
+++ b/ansible/image_host_docker.yml
@@ -11,3 +11,4 @@
   tasks:
     - include: roles/dokuwiki/tasks/docker.yml
     - include: roles/matrix/tasks/docker.yml
+    - include: roles/davros/tasks/docker.yml

--- a/ansible/roles/davros/files/supervisor/davros.conf
+++ b/ansible/roles/davros/files/supervisor/davros.conf
@@ -1,0 +1,4 @@
+[program:davros]
+directory = /opt/davros
+command = docker-compose up --no-color
+redirect_stderr = true

--- a/ansible/roles/davros/tasks/docker.yml
+++ b/ansible/roles/davros/tasks/docker.yml
@@ -1,0 +1,21 @@
+---
+- name: Create folder
+  file:
+    path: /opt/davros
+    state: directory
+    mode: 0755
+
+- name: Write compose file
+  template:
+    # `src` is a relative path because this file is included
+    # directly from `image_host_docker.yml`, not as a role.
+    src: ../templates/docker-compose.yml
+    dest: /opt/davros/docker-compose.yml
+    mode: 0644
+
+- name: Build docker image
+  when: build_docker_images
+  docker_service:
+    project_src: /opt/davros
+    build: true
+    stopped: true

--- a/ansible/roles/davros/tasks/main.yml
+++ b/ansible/roles/davros/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- include: tasks/docker.yml
+
+- name: Create supervisor config
+  copy:
+    src: supervisor/davros.conf
+    dest: /etc/supervisor/conf.d/davros.conf
+
+- name: Create nginx config
+  template:
+    src: nginx/davros.conf
+    dest: /etc/nginx/sites-enabled/davros.conf

--- a/ansible/roles/davros/templates/docker-compose.yml
+++ b/ansible/roles/davros/templates/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+services:
+
+  davros:
+    image: liquidinvestigations/davros:latest
+    volumes:
+      - content:/davros/data
+    ports:
+      - 51358:80
+
+volumes:
+  content: {}

--- a/ansible/roles/davros/templates/nginx/davros.conf
+++ b/ansible/roles/davros/templates/nginx/davros.conf
@@ -1,0 +1,8 @@
+server {
+  listen 80;
+  server_name davros.{{ liquid_domain }};
+  location / {
+    proxy_pass http://localhost:51358;
+    proxy_set_header Host $host;
+  }
+}

--- a/ansible/server.yml
+++ b/ansible/server.yml
@@ -18,3 +18,4 @@
     - hypothesis
     - dokuwiki
     - matrix
+    - davros


### PR DESCRIPTION
This PR references a vanilla davros docker image: [`liquidinvestigations/davros`](https://hub.docker.com/r/liquidinvestigations/davros/)`:latest`. The image is built from the [`docker`](https://github.com/liquidinvestigations/davros/tree/docker) branch of our davros fork, which does not include the oauth integration.
