### PR TITLE
longer timeout for matrix first boot

### DIFF
--- a/ansible/roles/matrix/files/initialize.d/matrix
+++ b/ansible/roles/matrix/files/initialize.d/matrix
@@ -9,7 +9,7 @@ supervisorctl start matrix
 function wait_url {
     X=0
     until $(curl --output /dev/null --silent --head --fail $1); do
-        sleep 3
+        sleep 7
         ((X=X+1))
         if [[ $X -gt 20 ]]; then
             echo "wait_url: $1 timed out" >&2


### PR DESCRIPTION
1 minute is too slow on the odroid c2. Let's try 2 minutes.