### PR TITLE
Liquid core api implementation

### DIFF
--- a/ansible/roles/liquid-core/tasks/main.yml
+++ b/ansible/roles/liquid-core/tasks/main.yml
@@ -9,6 +9,7 @@
   git:
     repo: https://github.com/liquidinvestigations/core.git
     dest: /opt/liquid-core/liquid-core
+    version: "{{ git_repo_versions.liquid_core }}"
 
 - name: Create the configuration file
   template:

--- a/ansible/roles/liquid-core/templates/local.py
+++ b/ansible/roles/liquid-core/templates/local.py
@@ -10,7 +10,7 @@ DATABASES = {
     }
 }
 
-INVOKE_HOOK = '/opt/common/libexec/invoke-hook'
+INVOKE_HOOK = 'sudo /opt/common/libexec/invoke-hook'
 
 HOOVER_APP_URL = 'http://hoover.{{ liquid_domain }}'
 HYPOTHESIS_APP_URL = 'http://hypothesis.{{ liquid_domain }}'


### PR DESCRIPTION
This banch pulls from the new `liquid-core` app, that also implements the API endpoints for configuring the system.