### PR TITLE
Fail jenkins job if any testsuite fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,11 +35,15 @@ node('cloud') {
         stage('CLOUD: Test and Archive') {
             parallel(
                 first_boot: {
-                    stage("CLOUD: Run first boot") {
-                        sh 'mkdir factory/images/liquid-cloud-x86_64'
-                        sh 'cp images/ubuntu-x86_64-raw.img factory/images/liquid-cloud-x86_64/disk.img'
-                        sh 'echo \'{"login": {"username": "liquid", "password": "liquid"}}\' > factory/images/liquid-cloud-x86_64/config.json'
-                        sh 'factory/factory --platform liquid-cloud-x86_64 run --smp 2 --memory 2048  --share .:/mnt/setup /mnt/setup/bin/run_first_boot_tests.py'
+                    try {
+                        stage("CLOUD: Run first boot") {
+                            sh 'mkdir factory/images/liquid-cloud-x86_64'
+                            sh 'cp images/ubuntu-x86_64-raw.img factory/images/liquid-cloud-x86_64/disk.img'
+                            sh 'echo \'{"login": {"username": "liquid", "password": "liquid"}}\' > factory/images/liquid-cloud-x86_64/config.json'
+                            sh 'factory/factory --platform liquid-cloud-x86_64 run --smp 2 --memory 2048  --share .:/mnt/setup /mnt/setup/bin/run_first_boot_tests.py'
+                        }
+                    }
+                    finally {
                         junit 'tests/results/*.xml'
                     }
                 },

--- a/bin/run_first_boot_tests.py
+++ b/bin/run_first_boot_tests.py
@@ -54,7 +54,7 @@ class PyTestWrapper:
             subprocess.run([command], shell=True, check=True, env=env)
         pytest_cmd = [self.pytest, '--junit-xml', self.xml_file]
         print("+", " ".join(pytest_cmd))
-        subprocess.run(pytest_cmd, cwd=self.chdir, env=env, check=False)
+        subprocess.run(pytest_cmd, cwd=self.chdir, env=env, check=True)
 
 
 class CoreTest(PyTestWrapper):
@@ -79,11 +79,16 @@ class SetupTest(PyTestWrapper):
 
 
 def run_tests():
+    fail = False
     for test_cls in [CoreTest, SetupTest]:
         try:
             test_cls().run()
         except subprocess.CalledProcessError:
-            print("Failed to run", test_cls.__name__)
+            print(test_cls.__name__, "failed")
+            fail = True
+
+    if fail:
+        return 1
 
 
 def wait_for_first_boot(wait_mins=10):
@@ -112,4 +117,4 @@ def cat_first_boot_logs():
 if __name__ == '__main__':
     wait_for_first_boot()
     cat_first_boot_logs()
-    run_tests()
+    sys.exit(run_tests())


### PR DESCRIPTION
I've tested that a failed unit test triggers a build failure and is also detected by jenkins via junit xml files.
