### PR TITLE
Only install strict dependencies

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -45,7 +45,7 @@
     - supervisor
     - nginx
     - python3
-    - python-virtualenv
+    - virtualenv
     - iptables
     - build-essential
     - default-jre-headless

--- a/py/images/builders/base.py
+++ b/py/images/builders/base.py
@@ -77,6 +77,11 @@ class BaseBuilder:
                     yield target
 
     def prepare_chroot(self, target):
+        apt_conf_liquid = target.mount_point / 'etc/apt/apt.conf.d/liquid'
+        with apt_conf_liquid.open('w', encoding='utf8') as f:
+            print('APT::Install-Recommends "false";', file=f)
+            print('APT::Install-Suggests "false";', file=f)
+
         target.chroot_run(['apt-get', '-qq', 'update'])
         target.chroot_run(['apt-get', '-qq', 'install', '-y', 'python'],
                           stdout=subprocess.DEVNULL)


### PR DESCRIPTION
This patch skips any suggested or recommended packages to keep our image as small as possible.