### PR TITLE
Noapps reconfigure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ node('cloud') {
         }
         stage('CLOUD: Prepare the build') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
             sh "wget -q $liquid_prerequisites_cloud_image -O images/pre.img.gz"
             sh 'zcat images/pre.img.gz > images/ubuntu-x86_64-raw.img'

--- a/Jenkinsfile.arm64
+++ b/Jenkinsfile.arm64
@@ -18,7 +18,6 @@ node('arm64') {
         }
         stage('ODROID C2: Prepare the build') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
             sh "wget -q $liquid_prerequisites_odroid_c2_image -O images/pre.img.gz"
             sh 'zcat images/pre.img.gz > images/ubuntu-odroid_c2-raw.img'

--- a/Jenkinsfile.arm64.noapps
+++ b/Jenkinsfile.arm64.noapps
@@ -25,7 +25,7 @@ node('arm64') {
             sh 'zcat images/pre.img.gz > images/ubuntu-odroid_c2-raw.img'
             sh 'rm images/pre.img.gz'
 
-            sh 'factory/factory run --smp 2 --memory 1024 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image odroid_c2 --image /mnt/images/ubuntu-odroid_c2-raw.img --skip-tags apps'
+            sh 'factory/factory run --smp 2 --memory 1024 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image odroid_c2 --image /mnt/images/ubuntu-odroid_c2-raw.img --no-apps'
 
             sh 'gzip -1 < images/ubuntu-odroid_c2-raw.img > liquid-odroid_c2-arm64-noapps-raw.img.gz'
             archiveArtifacts 'liquid-odroid_c2-arm64-noapps-raw.img.gz'

--- a/Jenkinsfile.arm64.noapps
+++ b/Jenkinsfile.arm64.noapps
@@ -19,7 +19,6 @@ node('arm64') {
             sh "#!/bin/bash\npython3 <(curl -sL https://github.com/liquidinvestigations/factory/raw/master/install.py) factory"
 
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
 
             sh "wget -q $liquid_noapps_prerequisites_odroid_c2_image -O images/pre.img.gz"

--- a/Jenkinsfile.noapps
+++ b/Jenkinsfile.noapps
@@ -20,7 +20,7 @@ node('cloud') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
             sh 'mkdir images'
 
-            sh 'factory/factory run --smp 2 --memory 2048 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image cloud --skip-tags apps'
+            sh 'factory/factory run --smp 2 --memory 2048 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image cloud --no-apps'
 
             sh 'gzip -1 < images/ubuntu-x86_64-raw.img > liquid-cloud-x86_64-noapps-raw.img.gz'
             archiveArtifacts 'liquid-cloud-x86_64-noapps-raw.img.gz'

--- a/Jenkinsfile.noapps
+++ b/Jenkinsfile.noapps
@@ -18,7 +18,6 @@ node('cloud') {
             sh "#!/bin/bash\npython3 <(curl -sL https://github.com/liquidinvestigations/factory/raw/master/install.py) factory"
 
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
 
             sh 'factory/factory run --smp 2 --memory 2048 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image cloud --skip-tags apps'

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,2 +1,1 @@
 /vars/config.yml
-/vars/liquidcore.yml

--- a/ansible/liquid.yml
+++ b/ansible/liquid.yml
@@ -4,7 +4,6 @@
   vars_files:
     - vars/defaults.yml
     - vars/config.yml
-    - vars/liquidcore.yml
     - vars/computed.yml
   roles:
     - common

--- a/ansible/roles/common/templates/options.json
+++ b/ansible/roles/common/templates/options.json
@@ -1,4 +1,5 @@
 {
   "domain": "{{ liquid_domain }}",
-  "use_https": {{ use_https | to_json }}
+  "use_https": {{ use_https | to_json }},
+  "apps": {{ liquid_apps | to_json }}
 }

--- a/jenkins-config.yml
+++ b/jenkins-config.yml
@@ -15,6 +15,6 @@ git_repo_versions:
     h_client_build: master
   discover: master
   liquid_core: master
-  setup: master
+  setup: noapps-reconfigure
   web_ui: master
   ui_templates: master

--- a/prerequisites/Jenkinsfile
+++ b/prerequisites/Jenkinsfile
@@ -17,7 +17,6 @@ node('cloud') {
         }
         stage('CLOUD: Build prerequisites image') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
             sh 'factory/factory run --smp 2 --memory 2048 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image cloud --tags prerequisites'
         }

--- a/prerequisites/Jenkinsfile.arm64
+++ b/prerequisites/Jenkinsfile.arm64
@@ -18,7 +18,6 @@ node('arm64') {
         }
         stage('ODROID C2: Build prerequisites image') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
             sh 'factory/factory run --smp 2 --memory 1024 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image odroid_c2 --tags prerequisites'
         }

--- a/prerequisites/Jenkinsfile.arm64.noapps
+++ b/prerequisites/Jenkinsfile.arm64.noapps
@@ -18,7 +18,6 @@ node('arm64') {
         }
         stage('ODROID C2: Build prerequisites image') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
-            sh 'touch setup/ansible/vars/liquidcore.yml'
             sh 'mkdir images'
             sh 'factory/factory run --smp 2 --memory 1024 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image odroid_c2 --image-size 2G --tags prerequisites --skip-tags apps'
         }

--- a/prerequisites/Jenkinsfile.arm64.noapps
+++ b/prerequisites/Jenkinsfile.arm64.noapps
@@ -19,7 +19,7 @@ node('arm64') {
         stage('ODROID C2: Build prerequisites image') {
             sh 'cp setup/jenkins-config.yml setup/ansible/vars/config.yml'
             sh 'mkdir images'
-            sh 'factory/factory run --smp 2 --memory 1024 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image odroid_c2 --image-size 2G --tags prerequisites --skip-tags apps'
+            sh 'factory/factory run --smp 2 --memory 1024 --share setup:/mnt/setup --share images:/mnt/images /mnt/setup/bin/jenkins_build /mnt/setup/bin/build_image odroid_c2 --image-size 2G --tags prerequisites --no-apps'
         }
         stage('ODROID C2: Archive prerequisites image') {
             sh 'gzip -1 < images/ubuntu-odroid_c2-raw.img > liquid-odroid_c2-arm64-prerequisites.img.gz'

--- a/py/images/builders/base.py
+++ b/py/images/builders/base.py
@@ -87,8 +87,8 @@ class BaseBuilder:
                           stdout=subprocess.DEVNULL)
         target.chroot_run(['apt-get', '-qq', 'clean'])
 
-    def run_ansible(self, playbook, host_pattern, tags=None, skip_tags=None):
-        cmd = ['ansible-playbook', '-i', 'hosts', '-l', host_pattern, playbook]
+    def run_ansible(self, host_pattern, tags=None, skip_tags=None):
+        cmd = ['ansible-playbook', '-i', 'hosts', '-l', host_pattern, 'liquid.yml']
         if tags:
             cmd += ['--tags', tags]
         if skip_tags:
@@ -107,4 +107,4 @@ class BaseBuilder:
 
     def build(self, image, tags, skip_tags):
         with self.open_target(image) as target:
-            self.run_ansible('liquid.yml', 'image', tags, skip_tags)
+            self.run_ansible('image', tags, skip_tags)

--- a/py/images/builders/base.py
+++ b/py/images/builders/base.py
@@ -1,4 +1,5 @@
 import re
+import json
 from pathlib import Path
 from contextlib import contextmanager
 import subprocess
@@ -87,12 +88,14 @@ class BaseBuilder:
                           stdout=subprocess.DEVNULL)
         target.chroot_run(['apt-get', '-qq', 'clean'])
 
-    def run_ansible(self, host_pattern, tags, skip_tags):
+    def run_ansible(self, host_pattern, tags, skip_tags, vars):
         cmd = ['ansible-playbook', '-i', 'hosts', '-l', host_pattern, 'liquid.yml']
         if tags:
             cmd += ['--tags', tags]
         if skip_tags:
             cmd += ['--skip-tags', skip_tags]
+        if vars:
+            cmd += ['--extra-vars', json.dumps(vars)]
         run(cmd, cwd=str(self.setup / 'ansible'))
 
     def prepare_image(self, image_size):
@@ -105,9 +108,9 @@ class BaseBuilder:
 
         return image
 
-    def build(self, image, tags, skip_tags):
+    def build(self, image, tags, skip_tags, vars):
         with self.open_target(image) as target:
-            self.run_ansible('image', tags, skip_tags)
+            self.run_ansible('image', tags, skip_tags, vars)
 
-    def update(self, tags, skip_tags):
-        self.run_ansible('local', tags, skip_tags)
+    def update(self, tags, skip_tags, vars):
+        self.run_ansible('local', tags, skip_tags, vars)

--- a/py/images/builders/base.py
+++ b/py/images/builders/base.py
@@ -108,3 +108,6 @@ class BaseBuilder:
     def build(self, image, tags, skip_tags):
         with self.open_target(image) as target:
             self.run_ansible('image', tags, skip_tags)
+
+    def update(self, tags, skip_tags):
+        self.run_ansible('local', tags, skip_tags)

--- a/py/images/builders/base.py
+++ b/py/images/builders/base.py
@@ -87,7 +87,7 @@ class BaseBuilder:
                           stdout=subprocess.DEVNULL)
         target.chroot_run(['apt-get', '-qq', 'clean'])
 
-    def run_ansible(self, host_pattern, tags=None, skip_tags=None):
+    def run_ansible(self, host_pattern, tags, skip_tags):
         cmd = ['ansible-playbook', '-i', 'hosts', '-l', host_pattern, 'liquid.yml']
         if tags:
             cmd += ['--tags', tags]

--- a/py/images/cmd.py
+++ b/py/images/cmd.py
@@ -10,6 +10,7 @@ def build_image():
     parser.add_argument('flavor', choices=setup.FLAVOURS.keys())
     parser.add_argument('--tags', default=None)
     parser.add_argument('--skip-tags', default=None)
+    parser.add_argument('--no-apps', action='store_false', dest='apps')
     parser.add_argument('-d', '--debug', action='store_true')
     parser.add_argument('--image', default=None)
     parser.add_argument('--image-size', default='8G')
@@ -19,6 +20,7 @@ def build_image():
         options.flavor,
         options.tags,
         options.skip_tags,
+        options.apps,
         options.image,
         options.image_size,
     )

--- a/py/images/setup.py
+++ b/py/images/setup.py
@@ -21,11 +21,11 @@ def build(flavor, tags, skip_tags, image_path, image_size):
         builder.install_qemu_utils()
         image = builder.prepare_image(image_size)
 
-    builder.build(image, tags, skip_tags)
+    builder.build(image, tags, skip_tags, None)
 
 
 def install(tags=None, skip_tags=None):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
     (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
-    builder.update(tags, skip_tags)
+    builder.update(tags, skip_tags, None)

--- a/py/images/setup.py
+++ b/py/images/setup.py
@@ -28,4 +28,4 @@ def install(tags=None, skip_tags=None):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
     (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
-    builder.run_ansible('liquid.yml', 'local', tags, skip_tags)
+    builder.run_ansible('local', tags, skip_tags)

--- a/py/images/setup.py
+++ b/py/images/setup.py
@@ -28,4 +28,4 @@ def install(tags=None, skip_tags=None):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
     (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
-    builder.run_ansible('local', tags, skip_tags)
+    builder.update(tags, skip_tags)

--- a/py/images/setup.py
+++ b/py/images/setup.py
@@ -9,7 +9,7 @@ FLAVOURS = {
 }
 
 
-def build(flavor, tags, skip_tags, image_path, image_size):
+def build(flavor, tags, skip_tags, apps, image_path, image_size):
     builder_cls = FLAVOURS[flavor]
     builder = builder_cls()
     builder.install_ansible()
@@ -21,10 +21,10 @@ def build(flavor, tags, skip_tags, image_path, image_size):
         builder.install_qemu_utils()
         image = builder.prepare_image(image_size)
 
-    builder.build(image, tags, skip_tags, None)
+    builder.build(image, tags, skip_tags, {'liquid_apps': apps})
 
 
 def install(tags=None, skip_tags=None):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
-    builder.update(tags, skip_tags, None)
+    builder.update(tags, skip_tags, {'liquid_apps': True})

--- a/py/images/setup.py
+++ b/py/images/setup.py
@@ -27,5 +27,4 @@ def build(flavor, tags, skip_tags, image_path, image_size):
 def install(tags=None, skip_tags=None):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
-    (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
     builder.update(tags, skip_tags, None)

--- a/py/liquid/reconfigure.py
+++ b/py/liquid/reconfigure.py
@@ -7,6 +7,13 @@ from .wifi import configure_wifi
 from .vpn import client
 from . import discover
 
+GLOBAL_LIQUID_OPTIONS = '/var/lib/liquid/conf/options.json'
+
+
+def get_liquid_options():
+    with open(GLOBAL_LIQUID_OPTIONS, encoding='utf8') as f:
+        return json.load(f)
+
 
 def run(cmd):
     print('+', cmd)
@@ -23,6 +30,7 @@ def on_reconfigure():
     print('on_reconfigure')
     options = json.load(sys.stdin)
     vars = {'liquid_{}'.format(k): v for k, v in options['vars'].items()}
+    vars['liquid_apps'] = get_liquid_options().get('apps', True)
 
     ansible(vars)
     run('/opt/common/initialize.sh')

--- a/py/liquid/reconfigure.py
+++ b/py/liquid/reconfigure.py
@@ -2,7 +2,7 @@ import sys
 import json
 from pathlib import Path
 import subprocess
-from images.setup import install
+from images.builders.cloud import Builder_cloud
 from .wifi import configure_wifi
 from .vpn import client
 from . import discover
@@ -14,6 +14,13 @@ def run(cmd):
     subprocess.run(cmd, shell=True, check=True)
 
 
+def ansible():
+    builder = Builder_cloud()
+    (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
+    (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
+    builder.update(tags='configure', skip_tags=None)
+
+
 def on_reconfigure():
     print('on_reconfigure')
     options = json.load(sys.stdin)
@@ -23,7 +30,7 @@ def on_reconfigure():
     with vars_path.open('w', encoding='utf8') as f:
         print(json.dumps(vars, indent=2, sort_keys=True), file=f)
 
-    install(tags='configure')
+    ansible()
     run('/opt/common/initialize.sh')
 
     print('configure_wifi')

--- a/py/liquid/reconfigure.py
+++ b/py/liquid/reconfigure.py
@@ -7,7 +7,6 @@ from .wifi import configure_wifi
 from .vpn import client
 from . import discover
 
-ANSIBLE_VARS = Path(__file__).parent.parent.parent / 'ansible' / 'vars'
 
 def run(cmd):
     print('+', cmd)
@@ -17,7 +16,6 @@ def run(cmd):
 def ansible(vars):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
-    (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
     builder.update('configure', None, vars)
 
 
@@ -26,11 +24,7 @@ def on_reconfigure():
     options = json.load(sys.stdin)
     vars = {'liquid_{}'.format(k): v for k, v in options['vars'].items()}
 
-    vars_path = ANSIBLE_VARS / 'liquidcore.yml'
-    with vars_path.open('w', encoding='utf8') as f:
-        print(json.dumps(vars, indent=2, sort_keys=True), file=f)
-
-    ansible({})
+    ansible(vars)
     run('/opt/common/initialize.sh')
 
     print('configure_wifi')

--- a/py/liquid/reconfigure.py
+++ b/py/liquid/reconfigure.py
@@ -14,11 +14,11 @@ def run(cmd):
     subprocess.run(cmd, shell=True, check=True)
 
 
-def ansible():
+def ansible(vars):
     builder = Builder_cloud()
     (builder.setup / 'ansible' / 'vars' / 'config.yml').touch()
     (builder.setup / 'ansible' / 'vars' / 'liquidcore.yml').touch()
-    builder.update(tags='configure', skip_tags=None)
+    builder.update('configure', None, vars)
 
 
 def on_reconfigure():
@@ -30,7 +30,7 @@ def on_reconfigure():
     with vars_path.open('w', encoding='utf8') as f:
         print(json.dumps(vars, indent=2, sort_keys=True), file=f)
 
-    ansible()
+    ansible({})
     run('/opt/common/initialize.sh')
 
     print('configure_wifi')


### PR DESCRIPTION
The _noapps_ build fails to reconfigure because it re-runs ansible *without* `--skip-tags apps`. This patch persists the `apps` flag in `/var/lib/liquid/conf/options.json`.

It also refactors the flow of variables through _setup_, eliminating `liquidcore.yml`, and passing vars through `ansible-playbook` command-line args, because `liquidcore.yml` was just duplicating state from `liquid-core`.
