### PR TITLE
First boot lan, no reconfigure

### DIFF
--- a/ansible/roles/network/files/hooks/first-boot/80-lan
+++ b/ansible/roles/network/files/hooks/first-boot/80-lan
@@ -1,16 +1,4 @@
 #!/bin/bash
 set -ex
 
-
-if [ -f /var/lib/liquid/lan/eth0_no_dhcp ]; then
-  echo "Skipping lan server (hotspot and eth0 dhcp)"
-  exit 0
-fi
-
-(
-  echo "Configuring lan"
-  set -x
-  /opt/liquid-core/libexec/manage putconfig lan '{"dhcp_range": "10.103.0.100,10.103.0.200,72h", "eth": true, "hotspot": {"ssid": "", "password": ""}, "ip": "10.103.0.1", "netmask": "255.255.255.0"}'
-)
-
-supervisorctl start lan-dnsmasq
+/opt/setup/libexec/first-boot-lan

--- a/libexec/first-boot-lan
+++ b/libexec/first-boot-lan
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+if __name__ == '__main__':
+    from pathlib import Path
+    import sys
+
+    repo = Path(__file__).resolve().parent.parent
+    sys.path.append(str(repo / 'py'))
+
+    from liquid import lan
+    lan.first_boot()

--- a/py/liquid/lan.py
+++ b/py/liquid/lan.py
@@ -107,3 +107,6 @@ def first_boot():
 
     print('starting dnsmasq for lan')
     subprocess.run(['supervisorctl', 'start', 'lan-dnsmasq'], check=True)
+
+    print('reloading nginx')
+    subprocess.run(['service', 'nginx', 'reload'], check=True)


### PR DESCRIPTION
Do the minimal amount of work to set up lan dhcp, without triggering the whole reconfigure logic.