### PR TITLE
Repair all

### DIFF
--- a/ansible/roles/common/files/sudoers.d/liquid-hooks
+++ b/ansible/roles/common/files/sudoers.d/liquid-hooks
@@ -1,2 +1,3 @@
-Defaults!/opt/common/libexec/invoke-hook env_keep=LIQUID_HOOK_DATA
+Defaults!/opt/common/libexec/invoke-hook env_keep="LIQUID_HOOK_DATA PYTHONUNBUFFERED"
+Defaults!/opt/setup/libexec/liquid-core-reconfigure env_keep="PYTHONUNBUFFERED"
 liquid-apps ALL=(ALL) NOPASSWD: /opt/common/libexec/invoke-hook, /opt/setup/libexec/liquid-core-reconfigure, /opt/setup/libexec/shutdown, /usr/bin/supervisorctl, /opt/setup/libexec/vpn-client-config

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -254,6 +254,13 @@
     src: nginx/https.conf
     dest: /var/lib/liquid/https/nginx/https.conf
 
+- name: nginx real_scheme variable
+  template:
+    src: nginx/real_scheme.conf
+    dest: /etc/nginx/conf.d/real_scheme.conf
+  tags:
+    - configure
+
 - name: Reload nginx after starting services
   copy:
     src: initialize.d/99-nginx-reload.sh

--- a/ansible/roles/common/templates/nginx/real_scheme.conf
+++ b/ansible/roles/common/templates/nginx/real_scheme.conf
@@ -1,0 +1,14 @@
+{% if (not use_https) and (http_scheme == 'https') -%}
+# we're using https, but it's a reverse proxy outside this host,
+# so we trust its X-FORWARDED-PROTO header.
+map $http_x_forwarded_proto $real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+{% else -%}
+# don't trust the X-FORWARDED-PROTO header because we're
+# not behind a reverse proxy
+map $http_x_forwarded_proto $real_scheme {
+  default $scheme;
+}
+{% endif -%}

--- a/ansible/roles/davros/templates/authproxy/config/basename.py
+++ b/ansible/roles/davros/templates/authproxy/config/basename.py
@@ -1,1 +1,1 @@
-LIQUID_URL = '{{ http_scheme }}://{{ liquid_domain }}'
+LIQUID_URL = "{{ 'https' if use_https else 'http' }}://{{ liquid_domain }}"

--- a/ansible/roles/davros/templates/nginx/davros.conf
+++ b/ansible/roles/davros/templates/nginx/davros.conf
@@ -3,7 +3,7 @@
     proxy_pass http://localhost:32437;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $real_scheme;
     client_max_body_size 512m;
   }
 {% endmacro %}

--- a/ansible/roles/hoover/templates/nginx/hoover.conf
+++ b/ansible/roles/hoover/templates/nginx/hoover.conf
@@ -3,7 +3,7 @@
     proxy_pass http://localhost:11940;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $real_scheme;
   }
 {% endmacro %}
 {% if use_https %}

--- a/ansible/roles/hoover/templates/search-local.py
+++ b/ansible/roles/hoover/templates/search-local.py
@@ -28,7 +28,7 @@ HOOVER_UPLOADS_ROOT = str(base_dir / 'uploads')
 HOOVER_ELASTICSEARCH_URL = 'http://localhost:14352'
 HOOVER_UI_ROOT = '/opt/hoover/ui/build'
 
-HOOVER_OAUTH_LIQUID_URL = "{{ http_scheme }}://{{ liquid_domain }}"
+HOOVER_OAUTH_LIQUID_URL = "{{ 'https' if use_https else 'http' }}://{{ liquid_domain }}"
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 from .secret_key import SECRET_KEY

--- a/ansible/roles/hypothesis/templates/nginx/hypothesis.conf
+++ b/ansible/roles/hypothesis/templates/nginx/hypothesis.conf
@@ -27,7 +27,7 @@ server {
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $real_scheme;
   }
 
   location /ws {

--- a/ansible/roles/liquid-core/templates/local.py
+++ b/ansible/roles/liquid-core/templates/local.py
@@ -11,7 +11,7 @@ CORS_ORIGIN_REGEX_WHITELIST = [
 ]
 CORS_ALLOW_CREDENTIALS = True
 
-INVOKE_HOOK = 'sudo /opt/common/libexec/invoke-hook'
+INVOKE_HOOK = 'sudo PYTHONUNBUFFERED=doit /opt/common/libexec/invoke-hook'
 
 {% if liquid_services.hoover.enabled %}
 HOOVER_APP_URL = 'http://hoover.{{ liquid_domain }}'
@@ -37,7 +37,7 @@ LIQUID_DOMAIN = '{{ liquid_domain }}'
 
 DISCOVERY_URL = 'http://localhost:13777'
 
-LIQUID_SETUP_RECONFIGURE = 'sudo /opt/setup/libexec/liquid-core-reconfigure'
+LIQUID_SETUP_RECONFIGURE = 'sudo PYTHONUNBUFFERED=doit /opt/setup/libexec/liquid-core-reconfigure'
 LIQUID_CORE_VAR = '/var/lib/liquid/core'
 LIQUID_SUPERVISORCTL = 'sudo /usr/bin/supervisorctl'
 

--- a/ansible/roles/liquid-core/templates/local.py
+++ b/ansible/roles/liquid-core/templates/local.py
@@ -14,23 +14,23 @@ CORS_ALLOW_CREDENTIALS = True
 INVOKE_HOOK = 'sudo PYTHONUNBUFFERED=doit /opt/common/libexec/invoke-hook'
 
 {% if liquid_services.hoover.enabled %}
-HOOVER_APP_URL = 'http://hoover.{{ liquid_domain }}'
+HOOVER_APP_URL = '{{ http_scheme }}://hoover.{{ liquid_domain }}'
 {% endif %}
 
 {% if liquid_services.hypothesis.enabled %}
-HYPOTHESIS_APP_URL = 'http://hypothesis.{{ liquid_domain }}'
+HYPOTHESIS_APP_URL = '{{ http_scheme }}://hypothesis.{{ liquid_domain }}'
 {% endif %}
 
 {% if liquid_services.dokuwiki.enabled %}
-DOKUWIKI_APP_URL = 'http://dokuwiki.{{ liquid_domain }}'
+DOKUWIKI_APP_URL = '{{ http_scheme }}://dokuwiki.{{ liquid_domain }}'
 {% endif %}
 
 {% if liquid_services.matrix.enabled %}
-MATRIX_APP_URL = 'http://riot.{{ liquid_domain }}'
+MATRIX_APP_URL = '{{ http_scheme }}://riot.{{ liquid_domain }}'
 {% endif %}
 
 {% if liquid_services.davros.enabled %}
-DAVROS_APP_URL = 'http://davros.{{ liquid_domain }}'
+DAVROS_APP_URL = '{{ http_scheme }}://davros.{{ liquid_domain }}'
 {% endif %}
 
 LIQUID_DOMAIN = '{{ liquid_domain }}'

--- a/ansible/roles/matrix/templates/nginx/matrix.conf
+++ b/ansible/roles/matrix/templates/nginx/matrix.conf
@@ -40,7 +40,7 @@ server {
     proxy_ssl_verify off;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $real_scheme;
   }
 }
 

--- a/py/liquid/reconfigure.py
+++ b/py/liquid/reconfigure.py
@@ -58,31 +58,32 @@ def on_reconfigure():
     old_vars = get_current_vars()
     first_boot = not old_vars
     repair = arg_options.repair
+    run_all = first_boot or repair
 
     print('old_vars:', json.dumps(old_vars))
     print('vars:', json.dumps(vars))
-    print('first_boot:', first_boot, 'repair:', repair)
+    print('first_boot:', first_boot, 'repair:', repair, 'run_all:', run_all)
 
     changes = set()
 
-    if vars['liquid_lan'] != old_vars.get('liquid_lan'):
+    if run_all or vars['liquid_lan'] != old_vars.get('liquid_lan'):
         changes.add('lan')
 
-    if vars['liquid_wan'] != old_vars.get('liquid_wan'):
+    if run_all or vars['liquid_wan'] != old_vars.get('liquid_wan'):
         changes.add('wan')
 
-    if vars['liquid_ssh'] != old_vars.get('liquid_ssh'):
+    if run_all or vars['liquid_ssh'] != old_vars.get('liquid_ssh'):
         changes.add('ssh')
 
-    if vars['liquid_vpn'] != old_vars.get('liquid_vpn'):
+    if run_all or vars['liquid_vpn'] != old_vars.get('liquid_vpn'):
         changes.add('vpn')
 
-    if vars['liquid_services'] != old_vars.get('liquid_services'):
+    if run_all or vars['liquid_services'] != old_vars.get('liquid_services'):
         changes.add('services')
 
     print('changes:', changes)
 
-    if first_boot or repair:
+    if run_all:
         tags = 'configure'
 
     else:
@@ -120,7 +121,7 @@ def on_reconfigure():
         else:
             run('systemctl stop ssh')
 
-    if first_boot or repair:
+    if run_all:
         run('supervisorctl restart all')
 
     else:


### PR DESCRIPTION
* "repairconfig" runs through the same steps as the welcome form, so it can fix most anything in the configuration. It can also enable/disable https support, provided that `/opt/setup/ansible/vars/config.yml` is first modified by hand.
* If we're doing https, but the SSL termination is handled by a reverse proxy outside our machine, then we trust its `X-Forwarded-Proto` header. This addresses https://github.com/liquidinvestigations/liquidinvestigations/issues/298 and a similar bug in the Hoover integration.
* Fix a long-standing issue with the reconfig logs being out of order by setting `PYTHONUNBUFFERED`.
