### PR TITLE
Fix moving dokuwiki to /var/lib/liquid

### DIFF
--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -69,13 +69,13 @@
     template:
       src: nginx/dokuwiki.conf
       dest: /etc/nginx/sites-enabled/dokuwiki.conf
-  
+
   - name: Create the initialization script
     copy:
       src: initialize.d/dokuwiki
       dest: /opt/common/initialize.d/21-dokuwiki.sh
       mode: 0755
-  
+
   - name: Subscribe to hooks
     copy:
       src: hooks/user

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -21,8 +21,6 @@
   stat:
     path: /opt/dokuwiki
   register: dokuwiki
-  tags:
-    - prerequisites
 
 - when: dokuwiki.stat.exists == False
   name: Install Dokuwiki
@@ -31,28 +29,29 @@
     file:
       path: /opt/dokuwiki
       state: directory
-    tags:
-      - prerequisites
 
   - name: Download DokuWiki stable source code
     shell: "wget https://download.dokuwiki.org/src/dokuwiki/dokuwiki-2017-02-19e.tgz -O - | tar -xzf - -C /opt/dokuwiki --strip 1"
-    tags:
-      - prerequisites
 
   - name: Create dokuwiki bootstrap template directory
     file:
       path: /opt/dokuwiki/lib/tpl/bootstrap-template
       state: directory
-    tags:
-      - prerequisites
 
   - name: Download DokuWiki bootstrap template coode
     shell: "wget https://github.com/LotarProject/dokuwiki-template-bootstrap3/tarball/2ae0cefbd25ce2304914bd01e6350d4eb83310f3 -O - | tar -xzf - -C /opt/dokuwiki/lib/tpl/bootstrap-template --strip 1"
-    tags:
-      - prerequisites
 
   - name: Move dokuwiki to /var/lib/liquid/dokuwiki
     shell: mv /opt/dokuwiki /var/lib/liquid
+
+  - name: Set up file permissions
+    file:
+      path: /var/lib/liquid/dokuwiki
+      state: directory
+      owner: www-data
+      group: www-data
+      recurse: yes
+      follow: yes
 
   - name: Link to new dokuwiki path
     file:
@@ -63,14 +62,6 @@
       owner: www-data
       group: www-data
 
-- name: Set up file permissions
-  file:
-    path: /opt/dokuwiki
-    state: directory
-    owner: www-data
-    group: www-data
-    recurse: yes
-    follow: yes
 
 - when: liquid_services.dokuwiki.enabled
   block:

--- a/ansible/roles/dokuwiki/tasks/main.yml
+++ b/ansible/roles/dokuwiki/tasks/main.yml
@@ -22,7 +22,7 @@
     path: /opt/dokuwiki
   register: dokuwiki
 
-- when: dokuwiki.stat.exists == False
+- when: dokuwiki.stat.exists == False or dokuwiki.stat.isdir == True
   name: Install Dokuwiki
   block:
   - name: Create /opt/dokuwiki directory


### PR DESCRIPTION
Fixed some problems with the prerequisites tag.
closes https://github.com/liquidinvestigations/setup/issues/131